### PR TITLE
Fix lured pokestops (#493)

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 args = get_args()
 flaskDb = FlaskDB()
 
-db_schema_version = 2
+db_schema_version = 3
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -196,8 +196,7 @@ class Pokestop(BaseModel):
     longitude = DoubleField()
     last_modified = DateTimeField(index=True)
     lure_expiration = DateTimeField(null=True, index=True)
-    active_pokemon_id = IntegerField(null=True)
-    encounter_id = CharField(max_length=50, null=True)
+    active_fort_modifier = CharField(max_length=50, null=True)
 
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
@@ -343,23 +342,19 @@ def parse_map(map_dict, step_location):
 
         for f in cell.get('forts', []):
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops
-                if 'lure_info' in f:
+                if 'active_fort_modifier' in f:
                     lure_expiration = datetime.utcfromtimestamp(
-                        f['lure_info']['lure_expires_timestamp_ms'] / 1000.0)
-                    active_pokemon_id = f['lure_info']['active_pokemon_id']
-                    encounter_id = f['lure_info']['encounter_id']
+                        f['last_modified_timestamp_ms'] / 1000.0) + timedelta(minutes=30)
                     webhook_data = {
-                        'encounter_id': b64encode(str(encounter_id)),
-                        'pokemon_id': active_pokemon_id,
                         'latitude': f['latitude'],
                         'longitude': f['longitude'],
-                        'disappear_time': calendar.timegm(lure_expiration.timetuple()),
                         'last_modified_time': f['last_modified_timestamp_ms'],
+                        'active_fort_modifier': f['active_fort_modifier'],
                         'is_lured': True
                     }
                     send_to_webhook('pokemon', webhook_data)
                 else:
-                    lure_expiration, active_pokemon_id, encounter_id = None, None, None
+                    lure_expiration, active_fort_modifier = None, None
 
                 pokestops[f['id']] = {
                     'pokestop_id': f['id'],
@@ -369,8 +364,7 @@ def parse_map(map_dict, step_location):
                     'last_modified': datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0),
                     'lure_expiration': lure_expiration,
-                    'active_pokemon_id': active_pokemon_id,
-                    'encounter_id': encounter_id
+                    'active_fort_modifier': active_fort_modifier,
                 }
 
             elif config['parse_gyms'] and f.get('type') is None:  # Currently, there are only stops and gyms
@@ -514,6 +508,13 @@ def database_migrate(db, old_ver):
 
     if old_ver < 2:
         migrate(migrator.add_column('pokestop', 'encounter_id', CharField(max_length=50, null=True)))
+
+    if old_ver < 3:
+        migrate(
+            migrator.add_column('pokestop', 'active_fort_modifier', CharField(max_length=50, null=True)),
+            migrator.drop_column('pokestop', 'encounter_id'),
+            migrator.drop_column('pokestop', 'active_pokemon_id')
+        )
 
     # Update database schema version
     Versions.update(val=db_schema_version).where(Versions.key == 'schema_version').execute()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -219,8 +219,6 @@ def insert_mock_data(position):
                         last_modified=datetime.now(),
                         # Every other pokestop be lured
                         lure_expiration=disappear_time if (i % 2 == 0) else None,
-                        active_pokemon_id=i,
-                        encounter_id=uuid.uuid4()
                         )
 
     for i in range(1, num_gym):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

* It appears the api has changed slightly here and the pokestop no
  longer contains info about the pokemon it's luring in, rather there
  is an identifier (active_fort_modifier) that denotes that the stop
  is lured. The value of this field is '9QM=' in such a case (in the
  testing that I've seen). Since the only modifier a pokestop can have
  currently is whether or not a lure is active, I've chosen to simply
  consider it lured if 'active_fort_modifier' exists. In the future
  if there are other types of modifieres for pokestops, we'll have to
  revisit this.